### PR TITLE
Clean up CI workflow channel config and split build steps

### DIFF
--- a/.github/workflows/guix-channel.yml
+++ b/.github/workflows/guix-channel.yml
@@ -36,20 +36,19 @@ jobs:
       run: |
         mkdir -p ~/.config/guix
         cat > ~/.config/guix/channels.scm << 'EOF'
-        (cons* (channel
-                 (name 'guix)
-                 (url "https://codeberg.org/guix/guix.git")
-                 (branch "master")
-                 (introduction
-                   (make-channel-introduction
-                     "9edb3f66fd807b096b48283debdcddccfea34bad"
-                     (openpgp-fingerprint
-                       "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA"))))
-               (channel
-                 (name 'mvox)
-                 (url "https://github.com/benzwick/guix-mvox")
-                 (branch "main"))
-               %default-channels)
+        (list (channel
+                (name 'guix)
+                (url "https://codeberg.org/guix/guix.git")
+                (branch "master")
+                (introduction
+                  (make-channel-introduction
+                    "9edb3f66fd807b096b48283debdcddccfea34bad"
+                    (openpgp-fingerprint
+                      "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA"))))
+              (channel
+                (name 'mvox)
+                (url "https://github.com/benzwick/guix-mvox")
+                (branch "main")))
         EOF
 
     # The apt package ships an older Guix; update to latest so it can
@@ -64,6 +63,11 @@ jobs:
       continue-on-error: true
       run: guix lint mfem mfem@4.5 mvox mvox-mfem-4.5
 
+    - name: Build mvox
+      run: guix build mvox
+
+    # guix install applies grafts (security patches) on top of the
+    # build.  Splitting build from install isolates graft failures.
     - name: Install mvox
       run: guix install mvox
 

--- a/.github/workflows/guix-shell.yml
+++ b/.github/workflows/guix-shell.yml
@@ -79,6 +79,12 @@ jobs:
     # install and the binary cannot find shared libraries. Guix's own
     # cmake-build-system handles this via its fix-runpath phase, but
     # that phase is not available when building manually in guix shell.
+    # Build the shell profile (MFEM, ITK, cmake, etc.) in a separate
+    # step so that dependency build failures are not conflated with
+    # cmake configuration errors.
+    - name: Build shell environment
+      run: guix shell --pure -L . -D mvox -- true
+
     - name: Configure mvox
       run: guix shell --pure -L . -D mvox -- cmake -B build -S mvox-src -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
 

--- a/.github/workflows/guix-slicer.yml
+++ b/.github/workflows/guix-slicer.yml
@@ -36,24 +36,23 @@ jobs:
       run: |
         mkdir -p ~/.config/guix
         cat > ~/.config/guix/channels.scm << 'EOF'
-        (cons* (channel
-                 (name 'guix)
-                 (url "https://codeberg.org/guix/guix.git")
-                 (branch "master")
-                 (introduction
-                   (make-channel-introduction
-                     "9edb3f66fd807b096b48283debdcddccfea34bad"
-                     (openpgp-fingerprint
-                       "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA"))))
-               (channel
-                 (name 'mvox)
-                 (url "file:///home/runner/work/guix-mvox/guix-mvox")
-                 (branch "main"))
-               (channel
-                 (name 'systole)
-                 (url "https://github.com/SystoleOS/guix-systole.git")
-                 (branch "main"))
-               %default-channels)
+        (list (channel
+                (name 'guix)
+                (url "https://codeberg.org/guix/guix.git")
+                (branch "master")
+                (introduction
+                  (make-channel-introduction
+                    "9edb3f66fd807b096b48283debdcddccfea34bad"
+                    (openpgp-fingerprint
+                      "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA"))))
+              (channel
+                (name 'mvox)
+                (url "file:///home/runner/work/guix-mvox/guix-mvox")
+                (branch "main"))
+              (channel
+                (name 'systole)
+                (url "https://github.com/SystoleOS/guix-systole.git")
+                (branch "main")))
         EOF
 
     - name: Update Guix

--- a/.github/workflows/guix-systole.yml
+++ b/.github/workflows/guix-systole.yml
@@ -39,24 +39,23 @@ jobs:
       run: |
         mkdir -p ~/.config/guix
         cat > ~/.config/guix/channels.scm << 'EOF'
-        (cons* (channel
-                 (name 'guix)
-                 (url "https://codeberg.org/guix/guix.git")
-                 (branch "master")
-                 (introduction
-                   (make-channel-introduction
-                     "9edb3f66fd807b096b48283debdcddccfea34bad"
-                     (openpgp-fingerprint
-                       "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA"))))
-               (channel
-                 (name 'mvox)
-                 (url "file:///home/runner/work/guix-mvox/guix-mvox")
-                 (branch "main"))
-               (channel
-                 (name 'systole)
-                 (url "https://github.com/SystoleOS/guix-systole.git")
-                 (branch "main"))
-               %default-channels)
+        (list (channel
+                (name 'guix)
+                (url "https://codeberg.org/guix/guix.git")
+                (branch "master")
+                (introduction
+                  (make-channel-introduction
+                    "9edb3f66fd807b096b48283debdcddccfea34bad"
+                    (openpgp-fingerprint
+                      "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA"))))
+              (channel
+                (name 'mvox)
+                (url "file:///home/runner/work/guix-mvox/guix-mvox")
+                (branch "main"))
+              (channel
+                (name 'systole)
+                (url "https://github.com/SystoleOS/guix-systole.git")
+                (branch "main")))
         EOF
 
     - name: Update Guix


### PR DESCRIPTION
## Summary
- Replace `cons*` + `%default-channels` with explicit `list` in channel, slicer, and systole workflows for consistency with build and shell workflows
- Split `guix build` from `guix install` in channel workflow to isolate graft failures from build failures
- Add separate "Build shell environment" step in shell workflow to separate dependency build errors from cmake configuration errors

## Test plan
- [ ] Verify all workflows pass on next scheduled or manual run